### PR TITLE
Wiki update for Treff 3000 #1756

### DIFF
--- a/config/canonical.json
+++ b/config/canonical.json
@@ -30445,6 +30445,8 @@
     "tags": {
       "brand": "Treff 3000",
       "name": "Treff 3000",
+      "brand:wikidata": "Q701755",
+      "brand:wikipedia": "de:Edeka",
       "shop": "supermarket"
     }
   },


### PR DESCRIPTION
Treff 3000 is a discount stores from Edeka Südwest